### PR TITLE
Import existing log helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "golin/monologgly",
+    "description": "Loggly helpers for php",
+    "require": {
+        "monolog/monolog": "^1.18"
+    },
+    "autoload": {
+        "psr-4": {
+            "Golin\\MonoLoggly\\": "src/"
+        }
+    },
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Stef Horner",
+            "email": "shorner@golin.com"
+        }
+    ]
+}

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,58 @@
+# Loggly Helpers
+
+### Setup with Laravel
+
+##### Config
+
+Add the following to `config/app.php`:
+
+```
+    'loggly-token' => env('LOGGLY_TOKEN'),
+```
+
+and add your loggly token to your .env file. Ommitting this will mean that the loggly monlog handler will not be loaded (and nothing will be sent to loggly) - basically, it's safe to not have this key when developing locally.
+
+##### Provider
+
+Add the following file, as `LogglyServiceProvider.php`, and put it in your application's service providers config in `config/app.php`.
+
+Update the `$name` property with your application's name.
+
+```
+<?php
+
+namespace App\Providers;
+
+use Golin\MonoLoggly\LogglyServiceProvider as BaseProvider;
+use Monolog\Monolog;
+
+class LogglyServiceProvider extends BaseProvider {
+
+    /**
+     * The log name. This should uniquely identify the log.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The minimum log level.
+     *
+     * @var int
+     */
+    protected $level = Monolog::DEBUG;
+
+    /**
+     * A place to construct any other processors that will be added to 
+     * the loggly handler.
+     *
+     * @return array   An array of callables objects
+     */
+    protected function processors()
+    {
+        return [];
+    }
+
+}
+
+```

--- a/src/LogglyServiceProvider.php
+++ b/src/LogglyServiceProvider.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Golin\MonoLoggly;
+
+use Golin\MonoLoggly\Processors\BacktraceLocation;
+use Golin\MonoLoggly\Processors\ExceptionInformation;
+use Golin\MonoLoggly\Processors\RequestInformation;
+use Illuminate\Log\Writer;
+use Illuminate\Support\ServiceProvider;
+use Monolog\Handler\LogglyHandler;
+use Monolog\Logger;
+
+class LogglyServiceProvider extends ServiceProvider {
+
+    /**
+     * The log name. This should uniquely identify the log
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The minimum log level
+     *
+     * @var int
+     */
+    protected $level = Logger::DEBUG;
+
+    /**
+     * @{inheritdoc}
+     */
+    public function boot()
+    {
+        $this->addLoggly(
+            $this->app['log']->getMonolog()
+        );
+    }
+
+    /**
+     * @{inheritdoc}
+     */
+    public function register() {}
+
+    /**
+     * Get the loggly token
+     *
+     * @return string
+     */
+    protected function token()
+    {
+        return config('app.loggly-token');
+    }
+
+    /**
+     * Add loggly to the given logger
+     *
+     * @param Monolog $monolog
+     * @param string  $tag
+     */
+    public function addLoggly(Logger $monolog)
+    {
+        if ($this->token()) {
+            $name = str_slug($this->name) . '-' . $this->app['env'];
+
+            $monolog->pushHandler(
+                $this->createHandler($name)
+            );
+        }
+    }
+
+    /**
+     * Create the loggly handler
+     *
+     * @return LogglyHandler
+     */
+    protected function createHandler($name)
+    {
+        $handler = new LogglyHandler($this->token() . '/tag/' . $name, $this->level);
+
+        // add a tag for the environment
+        $handler->addTag($this->app['env']);
+
+        $handler->pushProcessor(new ExceptionInformation);
+
+        $handler->pushProcessor(new BacktraceLocation(Writer::class));
+
+        $handler->pushProcessor(new RequestInformation(
+            $this->app['env'],
+            $this->app['request']->method(),
+            $this->app['request']->fullUrl()
+        ));
+
+        foreach ($this->processors() as $processor) {
+            $handler->pushProcessor($processor);
+        }
+
+        return $handler;
+    }
+
+    /**
+     * A place to construct any other processors to add to loggly
+     *
+     * @return array   An array of callables objects
+     */
+    protected function processors()
+    {
+        return [];
+    }
+
+}

--- a/src/Processors/BacktraceLocation.php
+++ b/src/Processors/BacktraceLocation.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Golin\MonoLoggly\Processors;
+
+use Monolog\Logger;
+
+class BacktraceLocation
+{
+    /**
+     * The class of the logger. This is used to figure out where the log was
+     * called from.
+     *
+     * @var string
+     */
+    protected $loggerClass;
+
+    public function __construct($loggerClass = Logger::class)
+    {
+        $this->loggerClass = $loggerClass;
+    }
+
+    /**
+     * Handle invokations of this object
+     *
+     * @param  array  $record
+     * @return array
+     */
+    public function __invoke(array $record)
+    {
+        return array_merge_recursive($record, ['context' => $this->context()]);
+    }
+
+    /**
+     * Get the context array
+     *
+     * @return array
+     */
+    public function context()
+    {
+        return [
+            'origin' => $this->backtraceInfo(),
+        ];
+    }
+
+    /**
+     * Get the backtrace information of whatever called the log
+     *
+     * @return array
+     */
+    protected function backtraceInfo()
+    {
+        // a flag to see if we have reached the logger in the backtrace
+        $foundLogger = false;
+
+        foreach (debug_backtrace() as $index => $trace) {
+            // loop through until we reach the logger class
+            if (!$foundLogger && isset($trace['class']) && $trace['class'] === $this->loggerClass) {
+                $foundLogger = true;
+            }
+
+            // once we've found the logger, keep looping until we get out of the
+            // logger class, then escape the loop
+            if ($foundLogger && !(isset($trace['class']) && $trace['class'] === $this->loggerClass)) {
+                break;
+            }
+        }
+
+        return $this->parseBacktrace($trace);
+    }
+
+    /**
+     * Parse the backtrace node into useful context information
+     *
+     * @param  array  $node
+     * @return array
+     */
+    protected function parseBacktrace(array $node)
+    {
+        $context = [];
+
+        // If there is file information, add it!
+        $context['file'] = [
+            'file' => isset($node['file']) ? $node['file'] : '',
+            'line' => isset($node['line']) ? $node['line'] : '',
+        ];
+
+        $context['function'] = $function = isset($node['function']) ? $node['function'] : null;
+
+        list($context['class'], $context['signature']) = $this->parseClassAndSignature(
+            isset($node['class']) ? $node['class'] : null,
+            $function
+        );
+
+        // If there is no signature, and the function name is "require", then it
+        // is requiring the file, and the arguments are a lie, so ignore them
+        $isRequiring = ($function === 'require' && !$context['signature']);
+
+        // Log the types of the arguments
+        if ($isRequiring) {
+            $context['arge'] = [];
+        } else {
+            $context['args'] = $this->parseArguments(
+                isset($node['args']) ? (array)$node['args'] : []
+            );
+        }
+
+        return $context;
+    }
+
+    /**
+     * If the function is a closure, it will be in the current namespace - this
+     * strips that out
+     *
+     * @param  string $function
+     * @return string
+     */
+    protected function parseFunction($function)
+    {
+        if (strpos($function, '{closure}') !== false) {
+            return '{closure}';
+        }
+
+        return $function;
+    }
+
+    /**
+     * Parse the class and function into a signature
+     *
+     * @param  string $class
+     * @param  string $function
+     * @return array
+     */
+    protected function parseClassAndSignature($class, $function)
+    {
+        $signature = null;
+        $function = $this->parseFunction($function);
+
+        // the signature key is a convenience key to describe where the log was
+        // called in terms of classes and methods.
+        if ($class) {
+            // if there is a class, add a signature - class@method
+            $class = $class;
+            $signature = sprintf('%s@%s', $class, $function);
+        } elseif($function === 'require') {
+            // if there is no class, and the function is require, it is likely a
+            // raw required file, so do nothing
+        } elseif($function) {
+            // if there is only a function, use that as a signature
+            $signature = $function;
+        }
+
+        return [$class, $signature];
+    }
+
+    /**
+     * Parse the arguments into their types
+     *
+     * @param  array  $arguments
+     * @return array
+     */
+    protected function parseArguments(array $arguments)
+    {
+        return array_map(function($argument) {
+            $type = gettype($argument);
+
+            return $type === 'object' ? get_class($argument) : $type;
+        }, (array) $arguments);
+    }
+
+}

--- a/src/Processors/ExceptionInformation.php
+++ b/src/Processors/ExceptionInformation.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Golin\MonoLoggly\Processors;
+
+class ExceptionInformation
+{
+    /**
+     * Handle invokations of this object
+     *
+     * @param  array  $record
+     * @return array
+     */
+    public function __invoke(array $record)
+    {
+        $result = null;
+
+        try {
+            $result = $this->parseExceptionMessage($record['message']);
+        } catch (\Exception $e) {
+            // if anything goes wrong, just pretend nothing ever happened. This
+            // is handled by the upcoming is null check
+        }
+
+        if (is_null($result)) {
+            return $record;
+        }
+
+        list($record['message'], $context) = $result;
+
+        return array_merge_recursive($record, compact('context'));
+    }
+
+    /**
+     * Parse the exception message into all of its parts
+     *
+     * @param  string $original
+     * @return array
+     */
+    protected function parseExceptionMessage($original)
+    {
+        $results = [];
+
+        // First, get the exception class from the message
+        $pattern = '/exception \'([a-zA-Z0-9\\\\]*)\' /';
+        if (preg_match($pattern, $original, $results) !== 1) {
+            return null;
+        }
+
+        list(,$class) = $results;
+        $escapedClass = preg_quote($class);
+
+        // Then get the message and location
+        $pattern = "/exception '$escapedClass' (with message '(.*)' )?in (\/.*)\:([0-9]*)\\n/";
+
+        if (preg_match($pattern, $original, $results) !== 1) {
+            return null;
+        }
+
+        list(,,$message, $file, $line) = $results;
+
+        $message = $message ?: '(no message)';
+
+        // Finally, get the stack trace
+        $pattern = "/Stack trace:\n(.*)/s";
+        $trace = preg_match($pattern, $original, $results) === 1 ?
+            $results[1] :
+            null;
+
+        return [$this->composeMessage($class, $message, $file, $line), [
+            'exception' => [
+                'exception' => $class,
+                'file'      => $file,
+                'line'      => $line,
+                'trace'     => $trace,
+            ],
+        ]];
+    }
+
+    /**
+     * Compose the new message
+     *
+     * @param  string $exception
+     * @param  string $message
+     * @param  string $file
+     * @param  string $line
+     * @return string
+     */
+    protected function composeMessage($exception, $message, $file, $line)
+    {
+        return sprintf('%s: %s [%s:%s]',
+            $exception,
+            $message,
+            $file,
+            $line
+        );
+    }
+}

--- a/src/Processors/RequestInformation.php
+++ b/src/Processors/RequestInformation.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Golin\MonoLoggly\Processors;
+
+class RequestInformation
+{
+    /**
+     * The environment
+     *
+     * @var string
+     */
+    protected $environment;
+    /**
+     * The method
+     *
+     * @var string
+     */
+    protected $method;
+    /**
+     * The url
+     *
+     * @var string
+     */
+    protected $url;
+
+
+    public function __construct($environment, $method, $url)
+    {
+        $this->environment = $environment;
+
+        $this->method = $method;
+        $this->url = $url;
+    }
+
+    /**
+     * Handle invokations of this object
+     *
+     * @param  array  $record
+     * @return array
+     */
+    public function __invoke(array $record)
+    {
+        return array_merge_recursive($record, ['context' => $this->context()]);
+    }
+
+    /**
+     * Get the useful context items
+     *
+     * @return array
+     */
+    public function context()
+    {
+        $context['environment'] = $this->environment;
+
+        $context['http'] = [
+            'method' => $this->method ? strtolower($this->method) : null,
+            'url'    => $this->url,
+        ];
+
+        // nicked from laravel's Application@runningInConsole method
+        $context['is-cli'] = php_sapi_name() == 'cli';
+
+        return $context;
+    }
+}


### PR DESCRIPTION
This adds a bunch of useful common meta information to the loggly monolog handler. In short:
- a flag to say if it's a command line action (as opposed to an http request)
- the current url and method, if it's an http request
- the file, line, and if available, the class and method that is calling the logger
- some exception data - by default, loggly has the whole exception message and entire stack trace as its main message. this extracts bits of it, and puts them in the context, and leaves a more concise message as the main one
